### PR TITLE
feature: Add createSubTask API with task and subtask population

### DIFF
--- a/src/graphql/resolvers/projectResolver.js
+++ b/src/graphql/resolvers/projectResolver.js
@@ -14,7 +14,11 @@ const projectResolver = {
       try {
         const project = await Project.findById(id)
           .populate('members')
-          .populate('tasks');
+          .populate({
+            path: 'tasks',
+            populate: [{ path: 'managers' }, { path: 'subTasks' }],
+          });
+
         if (!project) throw new Error('Project not found');
         return project;
       } catch (err) {

--- a/src/graphql/schema/index.js
+++ b/src/graphql/schema/index.js
@@ -23,6 +23,17 @@ const typeDefs = gql`
     priority: Boolean
   }
 
+  type SubTaskResponse {
+    id: ID!
+    name: String!
+    description: String
+    status: String!
+    priority: Boolean
+    progress: Int
+    managers: [Member]
+    subTasks: [Task]
+  }
+
   type Project {
     id: ID!
     name: String!
@@ -119,6 +130,8 @@ const typeDefs = gql`
     ): Task
 
     deleteTask(id: ID!): Task
+
+    createSubTask(parentTaskId: ID!, task: TaskInput!): SubTaskResponse
   }
 `;
 


### PR DESCRIPTION
- Modified `getProjectById` to include population of subTasks.
- Added `createSubTask` mutation to create a subtask for a given parent task.
- Updated GraphQL schema with `SubTaskResponse` type and `createSubTask` input.
- Implemented resolver logic for creating subtasks and linking them to the parent task.