### PR TITLE
Feature comment & like

### DIFF
--- a/src/graphql/resolvers/commentResolver.js
+++ b/src/graphql/resolvers/commentResolver.js
@@ -1,0 +1,191 @@
+import mongoose from 'mongoose';
+import { authMiddleware } from '../../middlewares/authMiddleware.js';
+import { Comment, Member, Task, Project } from '../../models/index.js';
+
+const commentResolver = {
+  Query: {
+    // 모든 댓글 조회 (회원, 태스크, 프로젝트 정보 populate)
+    getComments: async (_, __, context) => {
+      try {
+        await authMiddleware({ request: context.request });
+
+        const comments = await Comment.find()
+          .populate('memberId')
+          .populate('taskId');
+        if (!comments.length) return [];
+        return comments.map((comment) => ({
+          ...comment._doc,
+          id: comment._id.toString(),
+          member: comment.memberId,
+          task: comment.taskId,
+        }));
+      } catch (err) {
+        console.error('❌ Error in getComments:', err.message);
+        throw new Error('Failed to fetch comments: ' + err.message);
+      }
+    },
+
+    // 특정 댓글 조회
+    getCommentById: async (_, { id }, context) => {
+      await authMiddleware({ request: context.request });
+      try {
+        const comment = await Comment.findById(id)
+          .populate('memberId')
+          .populate('taskId');
+        if (!comment) throw new Error('Comment not found');
+        return {
+          ...comment._doc,
+          id: comment._id.toString(),
+          member: comment.memberId,
+          task: comment.taskId,
+        };
+      } catch (err) {
+        throw new Error('Failed to fetch comment');
+      }
+    },
+    // 태스크별 댓글 조회
+    getCommentsByTask: async (_, { taskId }, context) => {
+      await authMiddleware({ request: context.request });
+      try {
+        if (!mongoose.Types.ObjectId.isValid(taskId)) {
+          throw new Error(`Invalid taskId: ${taskId}`);
+        }
+        const comments = await Comment.find({ taskId })
+          .populate('memberId')
+          .populate('taskId');
+        if (!comments.length) return [];
+
+        return comments.map((comment) => ({
+          ...comment._doc,
+          id: comment._id.toString(),
+          member: comment.memberId,
+          task: comment.taskId,
+        }));
+      } catch (err) {
+        throw new Error('Failed to fetch comments by task');
+      }
+    },
+    // 프로젝트별 댓글 조회
+    getCommentsByProject: async (_, { projectId }, context) => {
+      const userData = await authMiddleware({ request: context.request });
+
+      try {
+        if (!mongoose.Types.ObjectId.isValid(projectId)) {
+          throw new Error(`Invalid projectId: ${projectId}`);
+        }
+        const comments = await Comment.find({ projectId })
+          .populate('memberId')
+          .populate('taskId');
+        if (!comments.length) return [];
+        return comments.map((comment) => ({
+          ...comment._doc,
+          id: comment._id.toString(),
+          member: comment.memberId,
+          task: comment.taskId,
+        }));
+      } catch (err) {
+        throw new Error('Failed to fetch comments by project');
+      }
+    },
+  },
+  Mutation: {
+    // 댓글 생성 (현재 로그인한 회원이 작성자로 등록)
+    createComment: async (_, { content, taskId, projectId }, context) => {
+      const userData = await authMiddleware({ request: context.request });
+
+      const member = await Member.findOne({ email: userData.email });
+
+      if (!member) {
+        throw new Error('❌ Member not found in database');
+      }
+
+      const memberId = member._id;
+
+      try {
+        if (!mongoose.Types.ObjectId.isValid(memberId)) {
+          throw new Error(`Invalid memberId: ${memberId}`);
+        }
+        if (taskId && !mongoose.Types.ObjectId.isValid(taskId)) {
+          throw new Error(`Invalid taskId: ${taskId}`);
+        }
+        if (projectId && !mongoose.Types.ObjectId.isValid(projectId)) {
+          throw new Error(`Invalid projectId: ${projectId}`);
+        }
+
+        const newComment = new Comment({
+          memberId,
+          content,
+          taskId: taskId ? new mongoose.Types.ObjectId(taskId) : undefined,
+          projectId: projectId
+            ? new mongoose.Types.ObjectId(projectId)
+            : undefined,
+        });
+
+        await newComment.save();
+
+        const savedComment = await Comment.findById(newComment._id)
+          .populate('memberId')
+          .populate('taskId');
+
+        return {
+          ...savedComment._doc,
+          id: savedComment._id.toString(),
+          member: savedComment.memberId,
+          task: savedComment.taskId,
+        };
+      } catch (err) {
+        throw new Error(`Failed to create comment: ${err.message}`);
+      }
+    },
+
+    // 댓글 수정 (내용 업데이트)
+    updateComment: async (_, { id, content }, context) => {
+      await authMiddleware({ request: context.request });
+      try {
+        const comment = await Comment.findByIdAndUpdate(
+          id,
+          { content, updatedAt: new Date() },
+
+          { new: true }
+        )
+          .populate('memberId')
+          .populate('taskId');
+
+        if (!comment) throw new Error('Comment not found');
+        return {
+          ...comment._doc,
+          id: comment._id.toString(),
+          member: comment.memberId,
+          task: comment.taskId,
+        };
+      } catch (err) {
+        throw new Error(`Failed to update comment: ${err.message}`);
+      }
+    },
+    // 댓글 삭제
+    deleteComment: async (_, { id }, context) => {
+      await authMiddleware({ request: context.request });
+      try {
+        const comment = await Comment.findByIdAndUpdate(
+          id,
+          { expiredAt: new Date() }, // ✅ 삭제 시 `expiredAt`을 현재 timestamp로 설정
+          { new: true }
+        )
+          .populate('memberId')
+          .populate('taskId');
+
+        if (!comment) throw new Error('Comment not found');
+        return {
+          ...comment._doc,
+          id: comment._id.toString(),
+          member: comment.memberId,
+          task: comment.taskId,
+        };
+      } catch (err) {
+        throw new Error(`Failed to delete comment: ${err.message}`);
+      }
+    },
+  },
+};
+
+export default commentResolver;

--- a/src/graphql/resolvers/index.js
+++ b/src/graphql/resolvers/index.js
@@ -1,4 +1,6 @@
 import authResolver from './authResolver.js';
+import commentResolver from './commentResolver.js';
+import likeResolver from './likeResolver.js';
 import memberResolver from './memberResolver.js';
 import projectResolver from './projectResolver.js';
 import roleResolver from './roleResolver.js';
@@ -10,6 +12,8 @@ const resolvers = {
     ...memberResolver.Query,
     ...taskResolver.Query,
     ...roleResolver.Query,
+    ...commentResolver.Query,
+    ...likeResolver.Query,
   },
   Mutation: {
     ...projectResolver.Mutation,
@@ -17,6 +21,8 @@ const resolvers = {
     ...taskResolver.Mutation,
     ...authResolver.Mutation,
     ...roleResolver.Mutation,
+    ...commentResolver.Mutation,
+    ...likeResolver.Mutation,
   },
 };
 

--- a/src/graphql/resolvers/likeResolver.js
+++ b/src/graphql/resolvers/likeResolver.js
@@ -1,0 +1,154 @@
+import mongoose from 'mongoose';
+import { authMiddleware } from '../../middlewares/authMiddleware.js';
+import { Like, Member } from '../../models/index.js';
+
+const likeResolver = {
+  Query: {
+    // 모든 좋아요 조회
+    getLikes: async (_, __, context) => {
+      await authMiddleware({ request: context.request });
+      try {
+        const likes = await Like.find()
+          .populate({
+            path: 'commentId',
+            populate: { path: 'memberId' }, // 글 작성자
+          })
+          .populate('memberId'); //좋아요를 누른 사용자
+
+        const responseLikes = likes.map((like) => ({
+          id: like._id.toString(),
+          comment: like.commentId
+            ? {
+                ...like.commentId.toObject(),
+                id: like.commentId._id.toString(),
+                member: like.commentId.memberId, // ✅ `commentId.memberId`를 `comment.member`로 변환
+              }
+            : null,
+          member: like.memberId, // ✅ `memberId`를 `member`로 변환
+        }));
+
+        return responseLikes;
+      } catch (err) {
+        throw new Error('Failed to fetch likes');
+      }
+    },
+    // 특정 댓글에 대한 좋아요 조회
+    getLikesByComment: async (_, { commentId }, context) => {
+      await authMiddleware({ request: context.request });
+      try {
+        if (!mongoose.Types.ObjectId.isValid(commentId)) {
+          throw new Error(`Invalid commentId: ${commentId}`);
+        }
+
+        const likes = await Like.find({ commentId })
+          .populate({
+            path: 'commentId',
+            populate: { path: 'memberId' }, // ✅ 댓글 작성자도 포함
+          })
+          .populate('memberId'); // ✅ 좋아요를 누른 사용자도 포함
+
+        // ✅ GraphQL에서 `commentId.memberId`를 `comment.member`로 변환
+        const responseLikes = likes.map((like) => ({
+          id: like._id.toString(),
+          comment: like.commentId
+            ? {
+                ...like.commentId.toObject(),
+                id: like.commentId._id.toString(),
+                member: like.commentId.memberId, // ✅ `commentId.memberId`를 `comment.member`로 변환
+              }
+            : null,
+          member: like.memberId, // ✅ `memberId`를 `member`로 변환
+        }));
+
+        return responseLikes;
+      } catch (err) {
+        throw new Error('Failed to fetch likes by comment');
+      }
+    },
+  },
+  Mutation: {
+    // 좋아요 생성 (현재 로그인한 회원이 좋아요)
+    createLike: async (_, { commentId }, context) => {
+      const userData = await authMiddleware({ request: context.request });
+      try {
+        if (!mongoose.Types.ObjectId.isValid(commentId)) {
+          throw new Error(`Invalid commentId: ${commentId}`);
+        }
+        const member = await Member.findOne({ email: userData.email });
+        if (!member) throw new Error('Member not found');
+
+        // 중복 좋아요 방지
+        const existingLike = await Like.findOne({
+          commentId,
+          memberId: member._id,
+        });
+        if (existingLike) {
+          throw new Error('You have already liked this comment');
+        }
+
+        const newLike = new Like({
+          commentId: new mongoose.Types.ObjectId(commentId),
+          memberId: member._id,
+        });
+        await newLike.save();
+        const like = await Like.findById(newLike._id)
+          .populate({
+            path: 'commentId',
+            populate: { path: 'memberId' }, // ✅ 댓글 작성자도 포함
+          })
+          .populate('memberId'); // ✅ 좋아요를 누른 사용자도 포함
+
+        return {
+          id: like._id.toString(),
+          comment: like.commentId
+            ? {
+                ...like.commentId.toObject(),
+                id: like.commentId._id.toString(),
+                member: like.commentId.memberId, // ✅ `commentId.memberId`를 `comment.member`로 변환
+              }
+            : null,
+          member: like.memberId, // ✅ `memberId`를 `member`로 변환
+        };
+      } catch (err) {
+        throw new Error(`Failed to create like: ${err.message}`);
+      }
+    },
+    // 좋아요 삭제 (해당 댓글에 대해 현재 회원이 누른 좋아요 삭제)
+    deleteLike: async (_, { commentId }, context) => {
+      const userData = await authMiddleware({ request: context.request });
+      try {
+        if (!mongoose.Types.ObjectId.isValid(commentId)) {
+          throw new Error(`Invalid commentId: ${commentId}`);
+        }
+
+        const member = await Member.findOne({ email: userData.email });
+        if (!member) throw new Error('Member not found');
+
+        const like = await Like.findOne({
+          commentId,
+          memberId: member._id,
+        })
+          .populate({
+            path: 'commentId',
+            populate: { path: 'memberId' },
+          })
+          .populate('memberId');
+        if (!like) {
+          throw new Error('Like not found');
+        }
+
+        await Like.findByIdAndDelete(like._id);
+        return {
+          ...like.toObject(),
+          id: like._id.toString(),
+          comment: like.commentId,
+          member: like.memberId,
+        };
+      } catch (err) {
+        throw new Error(`Failed to delete like: ${err.message}`);
+      }
+    },
+  },
+};
+
+export default likeResolver;

--- a/src/graphql/resolvers/likeResolver.js
+++ b/src/graphql/resolvers/likeResolver.js
@@ -1,12 +1,15 @@
 import mongoose from 'mongoose';
 import { authMiddleware } from '../../middlewares/authMiddleware.js';
 import { Like, Member } from '../../models/index.js';
+import { getIsClicked, getLikeCount } from '../../utils/commentUtils.js';
 
 const likeResolver = {
   Query: {
     // 모든 좋아요 조회
     getLikes: async (_, __, context) => {
-      await authMiddleware({ request: context.request });
+      const userData = await authMiddleware({ request: context.request });
+      const member = await Member.findOne({ email: userData.email });
+
       try {
         const likes = await Like.find()
           .populate({
@@ -15,17 +18,28 @@ const likeResolver = {
           })
           .populate('memberId'); //좋아요를 누른 사용자
 
-        const responseLikes = likes.map((like) => ({
-          id: like._id.toString(),
-          comment: like.commentId
-            ? {
+        const responseLikes = await Promise.all(
+          likes.map(async (like) => {
+            const likeCount = await getLikeCount(like.commentId._id); // ✅ 최신 좋아요 개수 가져오기
+            const isClicked = await getIsClicked(
+              like.commentId._id,
+              member._id
+            );
+
+            return {
+              id: like._id.toString(),
+              comment: {
                 ...like.commentId.toObject(),
                 id: like.commentId._id.toString(),
-                member: like.commentId.memberId, // ✅ `commentId.memberId`를 `comment.member`로 변환
-              }
-            : null,
-          member: like.memberId, // ✅ `memberId`를 `member`로 변환
-        }));
+                member: like.commentId.memberId,
+                likeCount,
+                isClicked,
+              },
+
+              member: like.memberId,
+            };
+          })
+        );
 
         return responseLikes;
       } catch (err) {
@@ -35,6 +49,9 @@ const likeResolver = {
     // 특정 댓글에 대한 좋아요 조회
     getLikesByComment: async (_, { commentId }, context) => {
       await authMiddleware({ request: context.request });
+      const userData = await authMiddleware({ request: context.request });
+      const member = await Member.findOne({ email: userData.email });
+
       try {
         if (!mongoose.Types.ObjectId.isValid(commentId)) {
           throw new Error(`Invalid commentId: ${commentId}`);
@@ -48,17 +65,28 @@ const likeResolver = {
           .populate('memberId'); // ✅ 좋아요를 누른 사용자도 포함
 
         // ✅ GraphQL에서 `commentId.memberId`를 `comment.member`로 변환
-        const responseLikes = likes.map((like) => ({
-          id: like._id.toString(),
-          comment: like.commentId
-            ? {
+        const responseLikes = await Promise.all(
+          likes.map(async (like) => {
+            const likeCount = await getLikeCount(like.commentId._id); // ✅ 최신 좋아요 개수 가져오기
+            const isClicked = await getIsClicked(
+              like.commentId._id,
+              member._id
+            );
+
+            return {
+              id: like._id.toString(),
+              comment: {
                 ...like.commentId.toObject(),
                 id: like.commentId._id.toString(),
-                member: like.commentId.memberId, // ✅ `commentId.memberId`를 `comment.member`로 변환
-              }
-            : null,
-          member: like.memberId, // ✅ `memberId`를 `member`로 변환
-        }));
+                member: like.commentId.memberId,
+                likeCount,
+                isClicked,
+              },
+
+              member: like.memberId,
+            };
+          })
+        );
 
         return responseLikes;
       } catch (err) {
@@ -97,16 +125,18 @@ const likeResolver = {
             populate: { path: 'memberId' }, // ✅ 댓글 작성자도 포함
           })
           .populate('memberId'); // ✅ 좋아요를 누른 사용자도 포함
-
+        const likeCount = await getLikeCount(commentId);
+        const isClicked = await getIsClicked(commentId, member._id);
+        console.log('like', JSON.stringify(like, null, 2));
         return {
           id: like._id.toString(),
-          comment: like.commentId
-            ? {
-                ...like.commentId.toObject(),
-                id: like.commentId._id.toString(),
-                member: like.commentId.memberId, // ✅ `commentId.memberId`를 `comment.member`로 변환
-              }
-            : null,
+          comment: {
+            ...like.commentId.toObject(),
+            id: like.commentId._id.toString(),
+            member: like.commentId.memberId,
+            likeCount,
+            isClicked,
+          },
           member: like.memberId, // ✅ `memberId`를 `member`로 변환
         };
       } catch (err) {
@@ -138,11 +168,16 @@ const likeResolver = {
         }
 
         await Like.findByIdAndDelete(like._id);
+        const likeCount = await getLikeCount(commentId); // ✅ 최신 좋아요 개수 가져오기
+        const isClicked = await getIsClicked(commentId, member._id); // ✅ 현재 사용자 좋아요 여부 가져오기
+
         return {
           ...like.toObject(),
           id: like._id.toString(),
           comment: like.commentId,
           member: like.memberId,
+          likeCount,
+          isClicked,
         };
       } catch (err) {
         throw new Error(`Failed to delete like: ${err.message}`);

--- a/src/graphql/schema/index.js
+++ b/src/graphql/schema/index.js
@@ -44,6 +44,25 @@ const typeDefs = gql`
     memberId: ID!
   }
 
+  type Comment {
+    id: ID!
+    member: Member
+    content: String!
+    task: Task
+    projectId: ID
+    likeCount: Int
+    isClicked: Boolean
+    createdAt: String
+    updatedAt: String
+    expiredAt: String
+  }
+
+  type Like {
+    id: ID!
+    comment: Comment
+    member: Member
+  }
+
   type SubTaskResponse {
     id: ID!
     name: String!
@@ -97,6 +116,16 @@ const typeDefs = gql`
     getRoles: [Role]
     getRoleById(id: ID!): Role
     getRolesByProjectId(projectId: ID!): [Role]
+
+    # Comment Queries
+    getComments: [Comment]
+    getCommentById(id: ID!): Comment
+    getCommentsByTask(taskId: ID!): [Comment]
+    getCommentsByProject(projectId: ID!): [Comment]
+
+    # Like Queries
+    getLikes: [Like]
+    getLikesByComment(commentId: ID!): [Like]
   }
 
   type CreateMemberResponse {
@@ -202,6 +231,15 @@ const typeDefs = gql`
       memberId: ID!
     ): Role
     deleteRole(id: ID!): Role
+
+    # Comment Mutations
+    createComment(content: String!, taskId: ID, projectId: ID): Comment
+    updateComment(id: ID!, content: String!): Comment
+    deleteComment(id: ID!): Comment
+
+    # Like Mutations
+    createLike(commentId: ID!): Like
+    deleteLike(commentId: ID!): Like
   }
 `;
 

--- a/src/models/comment.js
+++ b/src/models/comment.js
@@ -1,0 +1,51 @@
+import mongoose from 'mongoose';
+
+const commentSchema = new mongoose.Schema(
+  {
+    memberId: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Member',
+      required: true,
+    },
+    content: { type: String, required: true },
+    taskId: { type: mongoose.Schema.Types.ObjectId, ref: 'Task' },
+    projectId: { type: mongoose.Schema.Types.ObjectId, ref: 'Project' },
+    likeCount: { type: Number, default: 0 },
+    isClicked: { type: Boolean, default: false },
+    createdAt: { type: Date, default: Date.now },
+    updatedAt: { type: Date, default: null },
+    expiredAt: { type: Date, default: null },
+  },
+  {
+    timestamps: false,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+  }
+);
+
+commentSchema.virtual('likes', {
+  ref: 'Like',
+  localField: '_id',
+  foreignField: 'commentId',
+});
+
+commentSchema.virtual('computedLikeCount').get(function () {
+  if (this.populated('likes')) {
+    return this.likes.length;
+  }
+  return this.likeCount;
+});
+
+commentSchema.methods.getIsClicked = async function (
+  currentMemberId,
+  LikeModel
+) {
+  const existingLike = await LikeModel.findOne({
+    commentId: this._id,
+    memberId: currentMemberId,
+  });
+  return !!existingLike;
+};
+
+const Comment = mongoose.model('Comment', commentSchema);
+export default Comment;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,6 +1,8 @@
+import Comment from './comment.js';
+import Like from './like.js';
 import Member from './member.js';
 import Project from './project.js';
 import Role from './role.js';
 import Task from './task.js';
 
-export { Member, Task, Project, Role };
+export { Member, Task, Project, Role, Comment, Like };

--- a/src/models/like.js
+++ b/src/models/like.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const likeSchema = new mongoose.Schema({
+  commentId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Comment',
+    required: true,
+  },
+  memberId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Member',
+    required: true,
+  },
+});
+
+const Like = mongoose.model('Like', likeSchema);
+export default Like;

--- a/src/utils/commentUtils.js
+++ b/src/utils/commentUtils.js
@@ -1,0 +1,30 @@
+import { Like } from '../models/index.js';
+
+/**
+ * 현재 로그인한 사용자가 특정 댓글을 좋아요 눌렀는지 확인하는 함수
+ * @param {string} commentId - 확인할 댓글 ID
+ * @param {string} memberId - 현재 로그인한 사용자 ID
+ * @returns {Promise<boolean>} - 좋아요 여부 반환
+ */
+export const getIsClicked = async (commentId, memberId) => {
+  if (!commentId || !memberId) return false;
+
+  const existingLike = await Like.findOne({
+    commentId: commentId,
+    memberId: memberId,
+  });
+
+  return !!existingLike;
+};
+
+/**
+ * 특정 댓글의 좋아요 개수를 가져오는 함수
+ * @param {string} commentId - 좋아요 개수를 조회할 댓글 ID
+ * @returns {Promise<number>} - 좋아요 개수 반환
+ */
+export const getLikeCount = async (commentId) => {
+  if (!commentId) return 0;
+
+  const likeCount = await Like.countDocuments({ commentId });
+  return likeCount;
+};


### PR DESCRIPTION
- Added `Like` and `Comment` models
- Created mutations for adding, updating, and deleting comments
- Created mutations for liking and unliking comments

---

- **`createComment(content: String!, taskId: ID, projectId: ID): Comment`**

    - Creates a new comment with `createdAt` set automatically and `updatedAt` initialized as `null`.
- **`updateComment(id: ID!, content: String!): Comment`**

    - Updates a comment’s content and explicitly updates `updatedAt`.
- **`deleteComment(id: ID!): Comment`**

    - Implements soft delete by setting `expiredAt` instead of removing the comment.
- **`getComments(): [Comment]`**

    - Fetches all comments, filtering out expired ones.
- **`getCommentById(id: ID!): Comment`**

    - Retrieves a single comment by ID, including member and task details.
- **`getCommentsByTask(taskId: ID!): [Comment]`**

    - Retrieves all comments associated with a specific task.
- **`getCommentsByProject(projectId: ID!): [Comment]`**

    - Retrieves all comments associated with a specific project.

---

- **`createLike(commentId: ID!): Like`**

    - Allows a user to like a comment, preventing duplicate likes.
- **`deleteLike(commentId: ID!): Like`**

    - Allows a user to unlike a comment, ensuring proper deletion.
- **`getLikes(): [Like]`**

    - Fetches all likes, populating related comment and member details.
- **`getLikesByComment(commentId: ID!): [Like]`**

    - Retrieves all likes associated with a specific comment.

---

- **Refactored timestamp handling for comments**

    - `timestamps: false` to allow manual control over `createdAt`, `updatedAt`, and `expiredAt`.
    - Explicitly set `updatedAt: null` on creation and update it only when modified.
- **Implemented soft delete for comments (`expiredAt`)**

    - Comments are not physically deleted but marked as expired.
- **Improved GraphQL schema consistency**

    - Ensured `Comment` and `Like` schemas match GraphQL API requirements.
    - Populated related fields properly (`member`, `task`, `comment`).
